### PR TITLE
feature/categoryList

### DIFF
--- a/components/category/CardListContainer/index.tsx
+++ b/components/category/CardListContainer/index.tsx
@@ -11,8 +11,6 @@ import { ImgWrapper, StyledRoot } from "./style";
 function CardListContainer() {
   const lectureDataListState = useRecoilValue(lectureDataList);
 
-  console.log(lectureDataListState);
-
   return (
     <StyledRoot>
       {lectureDataListState ? (

--- a/components/category/SortingBox/index.tsx
+++ b/components/category/SortingBox/index.tsx
@@ -1,11 +1,18 @@
 import { getSortingLectureDataList } from "pages/apis/lectures.api";
 import React, { useState } from "react";
-import { useRecoilValue, useSetRecoilState } from "recoil";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import {
   currentCategoryState,
   currentSkillState,
-  isDisableState,
+  currentSortingDefault,
+  currentSortingState,
+  isOpenDefault,
+  isOpenState,
+  isSelectedState,
   lectureDataList,
+  sortingCriteria,
+  SortingItemType,
+  SortingType,
 } from "store/state";
 
 import SortingBtn from "../SortingBtn";
@@ -14,31 +21,7 @@ import { StyledRoot } from "./style";
 //todo(2) : active 효과 O
 //todo(3) : dropdown arrow icon isOpen에 따라서 위 아래 바꾸기 O
 //todo(4) : dropdown item선택하면 다른 선택된 item은 없애기 O
-//todo(5) : dropdown item선택하면 api 연결하기
-
-//isOpen 객체의 type정의
-export interface ISorting {
-  [key: string]: boolean;
-}
-//dropdown 내리면 나오는 선택 목록들 type정의
-export type SortingType = "총 소요시간" | "가격" | "개설일" | "반복시청 기간" | "질의응답 시간";
-export type SortingItemType =
-  | "긴 순"
-  | "짧은 순"
-  | "최근 순"
-  | "높은 순"
-  | "낮은 순"
-  | "빠름"
-  | "긴 순서"
-  | "짧은 순서";
-
-export type IDropListName = {
-  [key in SortingType]: SortingItemType[];
-};
-//dropdown에서 선택한 것 저장할 객체의 type정의
-export type ISelectedItemName = {
-  [key: string]: string;
-};
+//todo(5) : dropdown item선택하면 api 연결하기 O
 
 enum SortingText {
   //총 소요시간
@@ -59,72 +42,30 @@ enum SortingText {
 function SortingBox() {
   const category = useRecoilValue(currentCategoryState);
   const skill = useRecoilValue(currentSkillState);
-  const isDisable = useRecoilValue(isDisableState);
+  const [isOpen, setIsOpen] = useRecoilState(isOpenState);
+  const setIsSelected = useSetRecoilState(isSelectedState);
+  const setCurrentSorting = useSetRecoilState(currentSortingState);
   const setLectureDataList = useSetRecoilState(lectureDataList);
-  //가격과 개설일은 eslint자동수정으로 따옴표가 자꾸 빠지는데 문제없이 돌아갑니다
-  //dropListName은 드랍다운 클릭했을 때 나오는 목록 리스트들을 기준별로 저장한 것
-  const dropListName: IDropListName = {
-    "총 소요시간": ["긴 순", "짧은 순"],
-    가격: ["높은 순", "낮은 순"],
-    개설일: ["최근 순"],
-    "반복시청 기간": ["긴 순서", "짧은 순서"],
-    "질의응답 시간": ["빠름"],
-  };
-  //정렬하는 select형식의 button들을 만들기 위해 기준을 배열로 만들어서 map해주었다.
-  const sortingCriteria: SortingType[] = [
-    "총 소요시간",
-    "가격",
-    "개설일",
-    "반복시청 기간",
-    "질의응답 시간",
-  ];
-  //어떤 것이 선택되었는지를 표시하기 위한 객체. 처음에는 아무것도 선택되지 않았기 때문에 빈문자열.
-  // const selectedItemName: ISelectedItemName = {
-  //   "총 소요시간": "",
-  //   가격: "",
-  //   개설일: "",
-  //   "반복시청 기간": "",
-  //   "질의응답 시간": "",
-  // };
-  //드랍다운 한 개가 열리면 다른 것들이 닫혀야 함 : 여러 개를 한 번에 관리해줘야함
-  //=>드랍다운이 열렸는지 여부(isOpen)를 객체에 담는다. ex){"반복시청 기간": true, ... }
-  //isOpen객체를 만들기 위해 sortingCriteria 배열으로 forEach문을 사용해 값이 모두 false인 객체를 만들었다.
-  const sortingObject: ISorting = {};
 
-  sortingCriteria.forEach((element) => (sortingObject[element] = false));
-
-  const [isOpen, setIsOpen] = useState(sortingObject);
   //버튼 클릭 시, 버튼의 기준(sortingCriteria의 요소)을 가져와서 switch문에서 처리
-  //각각의 case마다 선택한 기준을 제외하곤 모두 false로 바꿔주고(sortingObject는 isOpen의 default값으로 들어간 객체)
+  //각각의 case마다 선택한 기준을 제외하곤 모두 false로 바꿔주고,
   //선택된기준을 key로 하는 value는 반대 값으로 바꿔준다.
   const handleOpenSorting = (criteria: SortingType) => {
     switch (criteria) {
       case criteria:
         setIsOpen({
-          ...sortingObject,
+          ...isOpenDefault,
           [criteria]: !isOpen[criteria],
         });
         break;
     }
   };
-  //선택된 기준의 경우만 무엇이 선택되었는지 버튼 안에 표시되어야함.
-  //중복 선택이 안되기 때문에 isOpen처럼 isSelected도 객체로.. 한번에 관리한다.
-  //초기값은 모두 false.
 
   //중복 정렬기능이 없기 때문에 한 곳에서 선택했으면 나머지는 초기화되어야함
   //어떤 기준의 어떤 기준 목록을 선택했는지 저장 필요 ex){"가격": "높은 순", ...}
   //초기값은 모두 빈 문자열
 
   //-> 모두 한 객체에 담아 관리하기
-  //isOpen과 같이 정렬 기준배열을 forEach문으로
-  const isSelectedObject: ISorting = {};
-  const selectedItemName: ISelectedItemName = {};
-
-  sortingCriteria.forEach((element) => (isSelectedObject[element] = false));
-  sortingCriteria.forEach((element) => (selectedItemName[element] = ""));
-
-  const [isSelected, setIsSelected] = useState(isSelectedObject);
-  const [selectedItem, setSelectedItem] = useState(selectedItemName);
 
   //드랍다운 아이템을 클릭하면 어떤 기준을 선택했고, 그 기준(value)의 어떤 목록(item)을 선택했는지 받아온다.
   //item이 '긴 순서' '짧은 순서'로 겹치는 경우가 있긴 한데 받아오는 value가 달라서 잘 작동되는 것 같다.
@@ -134,12 +75,12 @@ function SortingBox() {
   const handleClickSortingItem = async (value: SortingType, item: SortingItemType) => {
     switch (item) {
       case item:
-        setSelectedItem({
-          ...selectedItemName,
+        setCurrentSorting({
+          ...currentSortingDefault,
           [value]: item,
         });
         setIsSelected({
-          ...isSelectedObject,
+          ...isOpenDefault,
           [value]: true,
         });
         break;
@@ -150,7 +91,6 @@ function SortingBox() {
       const data = await getSortingLectureDataList(category.id, skill.id, ordering);
 
       if (data) {
-        console.log(data);
         setLectureDataList(data); //확인필요
       }
     }
@@ -162,14 +102,9 @@ function SortingBox() {
         <SortingBtn
           key={criteria}
           value={criteria}
-          dropListName={dropListName}
           onClickOpenSorting={handleOpenSorting}
-          isOpen={isOpen}
           onClickSortingItem={handleClickSortingItem}
-          isSelected={isSelected}
-          selectedItem={selectedItem}
           criteria={criteria}
-          isDisable={isDisable}
         >
           {criteria}
         </SortingBtn>

--- a/components/category/SortingBtn/index.tsx
+++ b/components/category/SortingBtn/index.tsx
@@ -1,43 +1,36 @@
 import { ArrowDown, ArrowUp, SmallArrowDown, SmallArrowUp } from "public/assets/icons";
 import React from "react";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
+import {
+  currentSortingState,
+  dropListName,
+  isDisableState,
+  ISelectedItemName,
+  isOpenState,
+  isSelectedState,
+  SortingItemType,
+  SortingType,
+} from "store/state";
 import { colors } from "styles/colors";
 import Screen from "styles/Screen";
 
-import {
-  IDropListName,
-  ISelectedItemName,
-  ISorting,
-  SortingItemType,
-  SortingType,
-} from "../SortingBox";
 import { BtnTextWrapper, CriteriaItem, DropDownBox, DropDownItem, StyledRoot } from "./style";
 //propstype 잘받아온거 맞는지 확인부...탁...해요..
 interface SortingBtnProps {
   value: SortingType;
   children: React.ReactNode;
-  dropListName: IDropListName;
-  selectedItem: ISelectedItemName;
-  isOpen: ISorting;
-  isDisable: boolean;
-  isSelected: ISorting;
   onClickOpenSorting: (criterial: SortingType) => void;
   onClickSortingItem: (value: SortingType, item: SortingItemType) => void;
   criteria: SortingType;
 }
 
 //sorting기준에 따라 dropDownList가 다르게보이도록 하자.
-function SortingBtn({
-  onClickOpenSorting,
-  onClickSortingItem,
-  isOpen,
-  isSelected,
-  isDisable,
-  dropListName,
-  selectedItem,
-  value,
-  criteria,
-}: SortingBtnProps) {
+function SortingBtn({ onClickOpenSorting, onClickSortingItem, value, criteria }: SortingBtnProps) {
+  const isDisable = useRecoilValue(isDisableState);
+  const isSelected = useRecoilValue(isSelectedState);
+  const isOpen = useRecoilValue(isOpenState);
+  const currentSorting = useRecoilValue(currentSortingState);
+
   return (
     <StyledRoot
       onClick={() => onClickOpenSorting(criteria)}
@@ -49,7 +42,7 @@ function SortingBtn({
         {isSelected[value] && (
           <>
             <CriteriaItem>|</CriteriaItem>
-            <CriteriaItem color={colors.mainBlue}>{selectedItem[value]}</CriteriaItem>
+            <CriteriaItem color={colors.mainBlue}>{currentSorting[value]}</CriteriaItem>
           </>
         )}
       </BtnTextWrapper>

--- a/components/category/SortingBtn/style.ts
+++ b/components/category/SortingBtn/style.ts
@@ -62,7 +62,7 @@ const DropDownBox = styled.ul`
   left: 0;
 
   width: 18rem;
-
+  z-index: 1;
   background: white;
   box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.16);
   border-radius: 1.2rem;

--- a/components/common/NavBar/LargeNavBar/index.tsx
+++ b/components/common/NavBar/LargeNavBar/index.tsx
@@ -6,6 +6,9 @@ import { useResetRecoilState } from "recoil";
 import {
   currentCategoryState,
   currentSkillState,
+  currentSortingState,
+  isDisableState,
+  isOpenState,
   lectureDataList,
   lectureSkillState,
 } from "store/state";
@@ -18,12 +21,18 @@ function LargeNavBar() {
   const resetSkillData = useResetRecoilState(currentSkillState);
   const resetLectureSkillData = useResetRecoilState(lectureSkillState);
   const resetCategoryData = useResetRecoilState(currentCategoryState);
+  const resetIsDisable = useResetRecoilState(isDisableState);
+  const resetIsOpen = useResetRecoilState(isOpenState);
+  const resetCurrentSorting = useResetRecoilState(currentSortingState);
 
   const handleResetLectureData = () => {
     resetLectureListData();
     resetSkillData();
     resetCategoryData();
     resetLectureSkillData();
+    resetIsDisable();
+    resetIsOpen();
+    resetCurrentSorting();
   };
 
   return (

--- a/store/state.ts
+++ b/store/state.ts
@@ -19,10 +19,101 @@ export const lectureSkillState = atom<LectureSkillData[] | null>({
   key: "lectureSkillState",
   default: null,
 });
-
+//--------------------카테고리 리스트 관련------------
 export const isDisableState = atom({
   key: "isDisableState",
   default: true,
+});
+
+export type SortingType = "총 소요시간" | "가격" | "개설일" | "반복시청 기간" | "질의응답 시간";
+
+//정렬하는 select형식의 button들을 만들기 위해 기준을 배열로 만든 후 리턴문에서 map 해주기
+export const sortingCriteria: SortingType[] = [
+  "총 소요시간",
+  "가격",
+  "개설일",
+  "반복시청 기간",
+  "질의응답 시간",
+];
+
+//sorting isOpen 객체의 type정의
+export interface ISorting {
+  [key: string]: boolean;
+}
+
+//드랍다운 한 개가 열리면 다른 것들이 닫혀야 함 : 여러 개를 한 번에 관리해줘야함
+//드랍다운이 열렸는지 여부(isOpen)를 객체에 담는다. ex){"반복시청 기간": true, ... }
+export const isOpenDefault = {
+  "총 소요시간": false,
+  가격: false,
+  개설일: false,
+  "반복시청 기간": false,
+  "질의응답 시간": false,
+};
+
+export const isOpenState = atom<ISorting>({
+  key: "isOpenState",
+  default: isOpenDefault,
+});
+
+//-----------isSelected----------------
+//중복 선택이 안되기 때문에 isOpen처럼 isSelected도 객체로.. 한번에 관리한다.
+//초기값은 모두 false.
+export type ISelectedItemName = {
+  [key in SortingType]: SortingItemType;
+};
+
+export const isSelectedState = atom<ISorting>({
+  key: "isSelectedState",
+  default: isOpenDefault,
+});
+
+//---------------currentSortingState-----------
+
+//dropdown 내리면 나오는 선택 목록들 type정의
+export type SortingItemType =
+  | "긴 순"
+  | "짧은 순"
+  | "최근 순"
+  | "높은 순"
+  | "낮은 순"
+  | "빠름"
+  | "긴 순서"
+  | "짧은 순서";
+
+export type IDropListName = {
+  [key in SortingType]: SortingItemType[];
+};
+
+export type ICurrentSortingType = {
+  [key in SortingType]: string;
+};
+
+//dropListName은 드랍다운 클릭했을 때 나오는 목록 리스트들을 기준별로 저장한 것
+//가격과 개설일은 eslint자동수정으로 따옴표가 자꾸 빠지는데 문제없이 돌아갑니다
+export const dropListName: IDropListName = {
+  "총 소요시간": ["긴 순", "짧은 순"],
+  가격: ["높은 순", "낮은 순"],
+  개설일: ["최근 순"],
+  "반복시청 기간": ["긴 순서", "짧은 순서"],
+  "질의응답 시간": ["빠름"],
+};
+
+//어떤 것이 선택되었는지를 표시하기 위한 객체. 처음에는 아무것도 선택되지 않았기 때문에 빈문자열.
+//선택된 드랍다운 메뉴가 들어갈 currentSorting의 디폴트값
+
+//선택된 기준의 경우만 무엇이 선택되었는지 버튼 안에 표시되어야함.
+export const currentSortingDefault: ICurrentSortingType = {
+  "총 소요시간": "",
+  가격: "",
+  개설일: "",
+  "반복시청 기간": "",
+  "질의응답 시간": "",
+};
+
+export const currentSortingState = atom<ICurrentSortingType>({
+  key: "currentSortingState",
+  default: currentSortingDefault,
 });
 
 interface CurrentCategory {


### PR DESCRIPTION
# 구현한 점
- sorting버튼에서 사용한 isOpen, isSelected, selectedItem state들을 모두 recoil로 관리하도록 수정
- 네비게이션 바에서 '전체강의' 버튼 눌렀을 경우 recoilState를 reset하도록 설정.
- type정의들을 모두 recoil store.state에 옮겼다
- 선택한 정렬기준들 모두 resest되기 때문에 category, skill누르지 않았을 때 disable처리되어 있으며, 드랍다운이 열려있지도 않게됨.
# 추가 필요
- 강의다시비교하기 버튼 -=> reset필요