### PR TITLE
Feature/result question

### DIFF
--- a/components/result/Question/QuestionModal/style.ts
+++ b/components/result/Question/QuestionModal/style.ts
@@ -7,7 +7,7 @@ export const StyledRoot = styled.section`
   margin: 0 auto;
   top: 50%;
   left: 50%;
-  z-index: 100;
+  z-index: 151;
   transform: translate(-50%, -50%);
   width: 120rem;
   height: 54.2rem;

--- a/components/result/Question/style.ts
+++ b/components/result/Question/style.ts
@@ -5,7 +5,7 @@ export const BackGround = styled.div`
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 99;
+  z-index: 150;
   background: ${colors.subBlack};
   opacity: 0.7;
   width: 100vw;


### PR DESCRIPTION
- 기존에 모달 창이 띄워졌을 때 nav bar에는 접근이 가능했었습니다. 모달 창의 특성상 새로운 페이지의 느낌을 주는 독립적인 페이지 하나를 페이지 이동 없이 띄우는 느낌을 주는 목적 상 접근하지 못하게 하는 것이 올바른 것 같다는 논의 하에 변경하게 되었습니다.