### PR TITLE
Feature/font setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "vercel-deploy": "next build && next export"
+    "vercel-deploy": "next build && next export",
+    "font-all-resize": "node ./scripts/transAllFontSize.mjs"
   },
   "dependencies": {
     "@types/react-responsive": "^8.0.5",

--- a/scripts/calcFontSize.mjs
+++ b/scripts/calcFontSize.mjs
@@ -1,0 +1,7 @@
+export const calcFontSize = (num) => {
+  const percent = 50; //root 퍼센트 변경할 시 이 부분을 변경하면 된다.
+  const applyingPercent = (16 * percent) / 1000;
+  const result = num * applyingPercent;
+
+  return Number(result.toFixed(2));
+};

--- a/scripts/transAllFontSize.mjs
+++ b/scripts/transAllFontSize.mjs
@@ -30,7 +30,10 @@ import { calcFontSize } from "./calcFontSize.mjs";
       startIndex = RegexStartIndex + lastIndex;
       lastIndex = fileContents.indexOf("rem", startIndex);
 
-      fileContents = replaceValue(fileContents, startIndex, lastIndex);
+      const replaceResult = replaceValue(fileContents, startIndex, lastIndex);
+
+      fileContents = replaceResult.replaceFile;
+      lastIndex = startIndex + replaceResult.replaceStringLen + 3;
     }
 
     return fileContents;
@@ -45,11 +48,14 @@ import { calcFontSize } from "./calcFontSize.mjs";
   };
 
   const replaceValue = (str, start, end) => {
-    const frontStr = str.substring(0, start + 1);
+    const frontStr = str.substring(0, start);
     const backStr = str.substring(end);
-    const transSize = calcFontSize(Number(str.substring(start + 2, end)));
+    const transSize = calcFontSize(Number(str.substring(start, end)));
 
-    return `${frontStr} ${transSize + backStr}`;
+    return {
+      replaceFile: `${frontStr}${transSize + backStr}`,
+      replaceStringLen: String(transSize).length,
+    };
   };
 
   const writeFile = (path) => {

--- a/scripts/transAllFontSize.mjs
+++ b/scripts/transAllFontSize.mjs
@@ -1,0 +1,62 @@
+import { readdirSync, readFileSync, writeFileSync } from "fs";
+
+import { calcFontSize } from "./calcFontSize.mjs";
+
+(() => {
+  const directory = ["./styles", "./pages"];
+
+  const searchDirectory = (path) => {
+    const dirContents = readdirSync(path);
+
+    dirContents.map((content) => {
+      if (isPageFile(path, content) || content.includes(".ts"))
+        return writeFile(`${path}/${content}`);
+      else if (content.includes(".tsx")) return;
+      else searchDirectory(`${path}/${content}`);
+    });
+  };
+
+  const searchFile = (path) => {
+    let fileContents = readFileSync(path, "utf8");
+    let lastIndex = 0;
+    let startIndex = 0;
+
+    while (lastIndex < fileContents.length && lastIndex !== -1) {
+      const findStartPoint = fileContents.substring(lastIndex);
+      const RegexStartIndex = findStr(findStartPoint, /[0-9.]{1,5}rem/);
+
+      if (RegexStartIndex === -1) break;
+
+      startIndex = RegexStartIndex + lastIndex;
+      lastIndex = fileContents.indexOf("rem", startIndex);
+
+      fileContents = replaceValue(fileContents, startIndex, lastIndex);
+    }
+
+    return fileContents;
+  };
+
+  const isPageFile = (path, file) => {
+    return path.includes("pages") && file.includes(".tsx");
+  };
+
+  const findStr = (str, findRegex) => {
+    return str.search(findRegex);
+  };
+
+  const replaceValue = (str, start, end) => {
+    const frontStr = str.substring(0, start + 1);
+    const backStr = str.substring(end);
+    const transSize = calcFontSize(Number(str.substring(start + 2, end)));
+
+    return `${frontStr} ${transSize + backStr}`;
+  };
+
+  const writeFile = (path) => {
+    let newFile = searchFile(path);
+
+    writeFileSync(path, newFile, "utf8");
+  };
+
+  directory.map((dir) => searchDirectory(dir));
+})();


### PR DESCRIPTION
- rem 단위로 작성된 값들 현재 값 -> 50%로 변경된 값 적용하는 코드 생성
root의 font-size를 62.5%로 유지해야하는 문제가 있었습니다. 
-> 사파리에서 최소 폰트 비율이 9px로 설정되어있는 경우가 있어서 적어도 10px로 맞춰두어야 특별한 경우를 제외하고 문제에 대응할 수 있었습니다. 
따라서 10px인 62.5%로 변경하기 위해서 현재 값에서 50%로 줄어들면 가지게 되는 px값을 계산해 적용해주었습니다.

근데 여러분.. 아주 슬프게도 생각해보니 모바일 버전에는 또 사이즈 유지를 해야하는지라ㅠㅜ 모바일 퍼센트를 늘리던지 하는 방식을 생각해봐야할 것 같다는 생각이 드네요..