### PR TITLE
강의 리스트 제목 4줄 이상 자르기 수정

### DIFF
--- a/components/category/CardBox/LargeCardBox/index.tsx
+++ b/components/category/CardBox/LargeCardBox/index.tsx
@@ -47,7 +47,7 @@ function LargeCardBox({ lecture }: Props) {
         <LikeIcon />
         <BookmarkIcon />
       </CardTop> */}
-      <TitleBox href={url} passHref>
+      <TitleBox>
         <TitleName href={url} target="_blank" rel="noopener noreferrer">
           {LectureTitle}
         </TitleName>

--- a/components/category/CardBox/LargeCardBox/style.ts
+++ b/components/category/CardBox/LargeCardBox/style.ts
@@ -34,31 +34,24 @@ export const CardTop = styled.div`
   }
 `;
 
-export const TitleBox = styled(Link)`
+export const TitleBox = styled.div`
   /* width: 30.4rem; */
   width: 26.8rem;
+  margin: 2.2rem 1.7rem 0rem 1.8rem;
+  height: 10rem;
   //제목 3줄이상 자르기, 말줄임표
-  height: 10.4rem;
-
-  white-space: normal;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  text-overflow: ellipsis;
-  overflow: hidden;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid ${colors.gray2};
 `;
 
 export const TitleName = styled.a`
-  height: 10rem;
-  margin: 2.2rem 1.7rem 0rem 1.8rem;
-  padding-bottom: 1rem;
   font-family: "Pretendard-SemiBold";
 
   color: ${colors.mildBlack};
   font-size: 2.2rem;
   line-height: 3rem;
   text-align: left;
-  border-bottom: 1px solid ${colors.gray2};
+
   //제목 4줄 이상이면 자르기
   white-space: normal;
   display: -webkit-box;


### PR DESCRIPTION
기존 구현된 부분
![image](https://user-images.githubusercontent.com/62272445/166908173-01bb5a88-0f8f-4862-96b4-3613c7a22c23.png)
- 3줄 마지막부분에  ...이 붙지만 4째 줄부터 제목이 이어짐 (박스 안에 가려져 있을 뿐)

### 수정한 부분
- TitleBox를 Link태그, TitleName을 a태그로 설정했는데, 외부 사이트로 이어주는 요소이기 때문에 Link태그를 쓰지 않아도 된다고 생각하여 div태그로 바꾸어주었습니다. (바꾸어주면서 TitleName에 있던 스타일을 TitleBox로 옮겨옴)
- 4줄 이상자르는 코드들을 div태그가 아니라 a태그로 옮김
- 