### PR TITLE
feat: mobile 정렬 및 구조 수정, 컴포넌트 이름수정

### DIFF
--- a/components/main/Footer/index.tsx
+++ b/components/main/Footer/index.tsx
@@ -7,12 +7,12 @@ import {
   CopyRight,
   FooterContainer,
   FooterTop,
+  ItemWrapper,
+  MenuList,
+  MenuListItem,
+  MenuTitle,
   ServiceIntro,
   ServiceIntroWrapper,
-  ServiceMenuBox,
-  ServiceMenuList,
-  ServiceMenuListItem,
-  ServiceMenuTitle,
   StyledRoot,
 } from "./style";
 function Footer() {
@@ -28,12 +28,12 @@ function Footer() {
               강의 찾는 시간 줄이고 성장에만 집중하세요
             </ServiceIntro>
           </ServiceIntroWrapper>
-          <ServiceMenuBox>
-            <ServiceMenuList>
+          <MenuList>
+            <div>
               <Screen desktop>
-                <ServiceMenuTitle>Service</ServiceMenuTitle>
+                <MenuTitle>Service</MenuTitle>
               </Screen>
-              <ServiceMenuListItem>
+              <MenuListItem>
                 <Link href="https://www.notion.so/lud2ns/ABOUT-_-Growto-9f2bd2594f914160b0ff08397a78a161">
                   <a
                     href="https://www.notion.so/lud2ns/ABOUT-_-Growto-9f2bd2594f914160b0ff08397a78a161"
@@ -43,24 +43,24 @@ function Footer() {
                     서비스 소개
                   </a>
                 </Link>
-              </ServiceMenuListItem>
-            </ServiceMenuList>
-            <ServiceMenuList>
+              </MenuListItem>
+            </div>
+            <ItemWrapper>
               <Screen desktop>
-                <ServiceMenuTitle>Contact Us</ServiceMenuTitle>
+                <MenuTitle>Contact Us</MenuTitle>
               </Screen>
-              <ServiceMenuListItem>
+              <MenuListItem>
                 <Link href="mailto:go.growto@gmail.com">기업 참여</Link>
-              </ServiceMenuListItem>
-              <ServiceMenuListItem>
+              </MenuListItem>
+              <MenuListItem>
                 <Link href="mailto:go.growto@gmail.com">문의하기</Link>
-              </ServiceMenuListItem>
-            </ServiceMenuList>
-            <ServiceMenuList>
+              </MenuListItem>
+            </ItemWrapper>
+            <div>
               <Screen desktop>
-                <ServiceMenuTitle>Social</ServiceMenuTitle>
+                <MenuTitle>Social</MenuTitle>
               </Screen>
-              <ServiceMenuListItem>
+              <MenuListItem>
                 <a
                   href="https://www.instagram.com/growto.official/"
                   target="_blank"
@@ -68,9 +68,9 @@ function Footer() {
                 >
                   <InstagramLogo />
                 </a>
-              </ServiceMenuListItem>
-            </ServiceMenuList>
-          </ServiceMenuBox>
+              </MenuListItem>
+            </div>
+          </MenuList>
         </FooterTop>
         <CopyRight>© 2022 Growto, Inc.</CopyRight>
       </FooterContainer>

--- a/components/main/Footer/style.ts
+++ b/components/main/Footer/style.ts
@@ -1,7 +1,8 @@
 import styled from "styled-components";
 import { colors } from "styles/colors";
 import { applyMediaQuery } from "styles/mediaQuery";
-const StyledRoot = styled.footer`
+
+export const StyledRoot = styled.footer`
   height: 38rem;
   padding: 7.6rem 2.5rem 6rem 2.5rem;
   background-color: ${colors.gray0};
@@ -9,12 +10,13 @@ const StyledRoot = styled.footer`
   display: flex;
   justify-content: center;
   ${applyMediaQuery("mobile")} {
+    padding: 7.6rem 0rem 6rem 0;
     padding-top: 0rem;
     width: 100%;
   }
 `;
 
-const FooterContainer = styled.div`
+export const FooterContainer = styled.div`
   width: 100%;
   max-width: 128rem;
   display: flex;
@@ -25,7 +27,7 @@ const FooterContainer = styled.div`
   }
 `;
 
-const FooterTop = styled.div`
+export const FooterTop = styled.div`
   border-bottom: solid 1px ${colors.gray3};
   padding-bottom: 6.2rem;
   display: flex;
@@ -36,7 +38,7 @@ const FooterTop = styled.div`
   }
 `;
 
-const CopyRight = styled.span`
+export const CopyRight = styled.span`
   font-family: "Pretendard-Regular";
   font-size: 1.2rem;
   color: ${colors.gray5};
@@ -45,7 +47,7 @@ const CopyRight = styled.span`
   }
 `;
 
-const ServiceIntroWrapper = styled.div`
+export const ServiceIntroWrapper = styled.div`
   margin-top: 0.2rem;
   margin-right: 4.5rem;
   min-width: 31.5rem;
@@ -57,7 +59,7 @@ const ServiceIntroWrapper = styled.div`
   }
 `;
 
-const ServiceIntro = styled.p`
+export const ServiceIntro = styled.p`
   margin-top: 3.4rem;
   font-family: "Pretendard-Medium";
   font-size: 1.6rem;
@@ -70,33 +72,27 @@ const ServiceIntro = styled.p`
   }
 `;
 
-const ServiceMenuBox = styled.div`
-  width: 45.2rem;
+export const MenuList = styled.ul`
   display: flex;
   flex-direction: row;
-  justify-content: space-around;
-  ${applyMediaQuery("mobile")} {
-    width: 100%;
-  }
-`;
-
-const ServiceMenuList = styled.ul`
-  display: flex;
-  flex-direction: column;
+  justify-content: space-between;
+  width: 36rem;
   min-width: 9.5rem;
   & + & {
     margin-left: 4.5rem;
   }
   ${applyMediaQuery("mobile")} {
     flex-direction: row;
+    justify-content: space-evenly;
     min-width: 6rem;
+    width: unset;
     & + & {
       margin-left: 1rem;
     }
   }
 `;
 
-const ServiceMenuTitle = styled.h4`
+export const MenuTitle = styled.h4`
   font-family: "Pretendard-Bold";
   font-size: 1.8rem;
   line-height: 2.2rem;
@@ -104,28 +100,18 @@ const ServiceMenuTitle = styled.h4`
   margin-bottom: 2.8rem;
 `;
 
-const ServiceMenuListItem = styled.li`
+export const MenuListItem = styled.li`
   font-family: "Pretendard-Regular";
   font-size: 1.4rem;
   line-height: 2.6rem;
   color: ${colors.gray5};
   ${applyMediaQuery("mobile")} {
     font-size: 1.2rem;
-    & + & {
-      margin-left: 3.2rem;
-    }
   }
 `;
 
-export {
-  CopyRight,
-  FooterContainer,
-  FooterTop,
-  ServiceIntro,
-  ServiceIntroWrapper,
-  ServiceMenuBox,
-  ServiceMenuList,
-  ServiceMenuListItem,
-  ServiceMenuTitle,
-  StyledRoot,
-};
+export const ItemWrapper = styled.span`
+  ${applyMediaQuery("mobile")} {
+    display: contents;
+  }
+`;


### PR DESCRIPTION
### 이슈 해결
모바일화면에서 가운데 정렬이 제대로 되지 않는 이슈가 있어서 작은 화면에서도 콘텐츠 요소가 잘 정렬되도록 수정하였습니다.

### 그 외 수정사항
- 'ServiceMenuList", "ServiceListItem"등과 같이 컴포넌트 이름이 길어서 'Service' 단어를 삭제했습니다.
- li태그 하나씩 모두 ul태그로 감싸고 있는 구조 -> li모두 합쳐서 한개의 ul이 감싸고 있는 구조 (모바일과 desktop 구성이 달라서 이런 방법을 사용한 것 같은데 css 정렬로 해결했습니다 - width: contents를 사용했습니다 )
![image](https://user-images.githubusercontent.com/62272445/169301976-608aa956-c2d1-4c61-bcf6-95de4b39f325.png)
